### PR TITLE
0.3.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -100,34 +100,42 @@ class RedisStats {
                 if (err) debug(err);
 
                 // e.g. ['used_memory','100mb']
-                let status = internals.renderStatus(result);
+                let statuses = internals.renderStatus(result);
+                for (let status of statuses) {                
+                    if (!status[1]) continue; // this will occur only for headers (e.g. # Server)
 
-                status.forEach((statusItem) => {
-                    // this.stats is the list of stats we're interested in e.g. ['used_memory', 'uptime_in_seconds']
-                    if (this.stats.indexOf(statusItem[0]) > -1) {
-                        // statusItem[0] will be the item (e.g. used_memory)
-                        // statusItem[1] will be the value (e.g. 100mb)
+                    // extra loop to deal with cases like {"db0":"keys=100,avg_ttl=100"}
+                    for (let statusItem of status[1].split(',')) {
+                        // in the case of {"db0":"keys=100,avg_ttl=100"}, statusKey will be set to db0:keys 
+                        let statusKey = statusItem.split('=').length > 1 ? status[0] + ':' + statusItem.split('=')[0] : status[0];
 
-                        // e.g. "status:127.0.0.1:6379:used_memory"
-                        let key = this.prefix + redis.options.host + ':' + redis.options.port + ':' + [statusItem[0]] ;                        
-                        let time = new Date();                        
-                        let obj = {};
-                        // e.g. {'2016-09-10T10:00:00.000Z' : '100mb'}                        
-                        obj[time.toISOString()] = statusItem[1];
+                        // in the case of {"db0":"keys=100,avg_ttl=100"}, statusVal will be set to 100 
+                        let statusVal = statusItem.split('=').length > 1 ? statusItem.split('=')[1] : statusItem;
 
-                        internals.addToZsets(this.cluster || redis, key, time.getTime(), obj);
-                    
-                        // e.g. "status:127.0.0.1:6379:hourly:used_memory"
-                        key = this.prefix + redis.options.host + ':' + redis.options.port + ':hourly:' + [statusItem[0]];
-                        var hourTime = time.toISOString().slice(0,13) + ':00:00.000Z';
-                        internals.addAvgToZsets(this.cluster || redis, key, new Date(hourTime).getTime(), hourTime, Number.parseFloat(statusItem[1]));                    
+                        // if the current key matches a key we want to track 
+                        if (this.stats.indexOf(statusKey) > -1) {
 
-                        // e.g. "status:127.0.0.1:6379:daily:used_memory"
-                        key = this.prefix + redis.options.host + ':' + redis.options.port + ':daily:' + [statusItem[0]];
-                        var dayTime = time.toISOString().slice(0,10) + 'T00:00:00.000Z';
-                        internals.addAvgToZsets(this.cluster || redis, key, new Date(dayTime).getTime(), dayTime, Number.parseFloat(statusItem[1]));                    
-                    }
-                });
+                            // e.g. "status:127.0.0.1:6379:used_memory"
+                            let key = this.prefix + redis.options.host + ':' + redis.options.port + ':' + [statusKey] ;                        
+                            let time = new Date();                        
+                            let obj = {};
+                            // e.g. {'2016-09-10T10:00:00.000Z' : '100mb'}                        
+                            obj[time.toISOString()] = statusVal;
+
+                            internals.addToZsets(this.cluster || redis, key, time.getTime(), obj);
+                        
+                            // e.g. "status:127.0.0.1:6379:hourly:used_memory"
+                            key = this.prefix + redis.options.host + ':' + redis.options.port + ':hourly:' + [statusKey];
+                            var hourTime = time.toISOString().slice(0,13) + ':00:00.000Z';
+                            internals.addAvgToZsets(this.cluster || redis, key, new Date(hourTime).getTime(), hourTime, Number.parseFloat(statusVal));                    
+
+                            // e.g. "status:127.0.0.1:6379:daily:used_memory"
+                            key = this.prefix + redis.options.host + ':' + redis.options.port + ':daily:' + [statusKey];
+                            var dayTime = time.toISOString().slice(0,10) + 'T00:00:00.000Z';
+                            internals.addAvgToZsets(this.cluster || redis, key, new Date(dayTime).getTime(), dayTime, Number.parseFloat(statusVal));                    
+                        }
+                    };
+                }
             }); 
         });    
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-stats",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Automatic generation of stats using the redis INFO command",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -12,6 +12,9 @@ var redisStats = new RedisStats({
 redisStats.initialize();
 ```
 
+## Demo
+A working example of a website displaying data collected by redis-stats can be seen at in the project [Redis Live on github](https://github.com/lawrips/redis-live). A working example of this can be viewed / interacted with at [www.redislive.com](http://www.redislive.com)
+
 ## How it works
 Include and initialize this library to automatically take snapshots of your redis server(s) using the rediS INFO command. By having these stats automatically generated in the background, it becomes easy to create graphs on memory usage, # connected clients, uptime, changes since last backup, etc. 
 
@@ -89,6 +92,23 @@ Daily, as you'd expect is:
 1) "{\"2016-09-17T00:00:00.000Z\":19255914.94736842,\"n\":1440}"
 1) "{\"2016-09-18T00:00:00.000Z\":29235914.94736842,\"n\":1440}"
 ```
+
+### Special cases
+
+Some sections returened by the redis INFO command are comma separated lists. The most interesting example of this is "Keyspace". The raw info returned in this section looks something like:
+```
+db0 // database name (default)
+keys=37,expires=2,avg_ttl=20648 // comma separated list of values
+```
+As of version 0.3, redis-stats now supports the extraction and recording of these values. These values need to be specified slightly differently in the constructor. For example, to record the "keys" value for "db0", you should pass in "db0:keys" as follows:  
+
+```
+var redisStats = new RedisStats({
+    servers: [{'host': 'localhost', 'port': 6379}],
+    stats: ['db0:keys'],
+});
+```
+Now the # of keys for db0 will be automatically recorded. 
 
 ### Displaying Stats
 You can consume this data yourself easily by just querying redis directly.


### PR DESCRIPTION
New feature which automatically extracts the stats / values out of comma separated values and records them. An example is the keyspace section from the INFO command. 

Here, values like:

```
db0:keys=37,expires=2,avg_ttl=20648
```

Can now be referenced. For example "db0:keys" passed into the constructor will now record the # of keys to be recorded automatically for db0
