### PR TITLE
minor change to allow password to be supplied in the servers param at startup

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -37,10 +37,13 @@ class RedisStats {
         this.redises = [];        
         this.servers.forEach((server) => {
             let redisOptions = JSON.parse(JSON.stringify(this.redisOptions));
-            redisOptions.host = server.host;
-            redisOptions.port = server.port;
+            if (redisOptions) {
+                Object.keys(redisOptions).forEach((key) => {
+                    server[key] = redisOptions[key];
+                });                
+            }
 
-            this.redises.push(new Redis(redisOptions));
+            this.redises.push(new Redis(server));
         });
 
         // if cluster param was passed in, we use this for writing status back

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-stats",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Automatic generation of stats using the redis INFO command",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ The full list of options accepted by the Redis-Stats constructor:
 
 ```js
 {
-    servers: [{'host':'host', 'port':'port'}],  // array of servers to be monitored   
+    servers: [{'host':'host', 'port':'port'}],  // array of servers to be monitored ('password' can be supplied here also)
     stats: ['uptime_in_seconds','used_memory'],   // list of stats to monitor - full list is here http://redis.io/commands/INFO
     redisOptions : {},  // (optional) standard redis options (e.g. 'password')
     prefix: 'myserverstats:',    // (optional) prefix to insert in front of keys in redis for any persisted stats 


### PR DESCRIPTION
e.g. 
{'server':'localhost', port: 6379, password:'secret'}

Was previously only available in redisOptions